### PR TITLE
fix: account disconnecting event listener

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,9 +24,15 @@ function App() {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    connectWallet();
     fetchRaffleData();
     listenForEvents();
+    if (window.ethereum) {
+      window.ethereum.on('accountsChanged', (accounts) => {
+        setAccount(accounts[0]);
+      })
+    } else {
+      setAccount(null);
+    }
   }, []);
 
   // Connect MetaMask


### PR DESCRIPTION
Fixed button and connected account label text. If you switch between wallets now the label will dinamically display the address of the connected wallet and also, if you disconnect the button text will change back to: "Connect account".